### PR TITLE
Add battle drawing timer system

### DIFF
--- a/UnityGameFiles/Assets/Scenes/DrawingBattleScene.unity
+++ b/UnityGameFiles/Assets/Scenes/DrawingBattleScene.unity
@@ -1698,6 +1698,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 422379369}
   m_CullTransparentMesh: 1
+--- !u!1 &471646970
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 471646971}
+  - component: {fileID: 471646973}
+  - component: {fileID: 471646972}
+  m_Layer: 0
+  m_Name: TimerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &471646971
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 471646970}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1999336766}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 400.17, y: 626.8}
+  m_SizeDelta: {x: 183.66, y: 107.59}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &471646972
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 471646970}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 103.75452, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &471646973
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 471646970}
+  m_CullTransparentMesh: 1
 --- !u!1 &479280507
 GameObject:
   m_ObjectHideFlags: 0
@@ -3096,6 +3232,7 @@ MonoBehaviour:
   enemyTurnPanel: {fileID: 890739920}
   turnDelay: 1.5
   actionTextDelay: 2
+  battleTimer: {fileID: 1999336767}
 --- !u!4 &948641826
 Transform:
   m_ObjectHideFlags: 0
@@ -3745,6 +3882,7 @@ RectTransform:
   - {fileID: 1504881219}
   - {fileID: 657589480}
   - {fileID: 836146061}
+  - {fileID: 1999336766}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -5662,6 +5800,146 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1999336765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1999336766}
+  - component: {fileID: 1999336767}
+  m_Layer: 0
+  m_Name: BattleTimerPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1999336766
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1999336765}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 471646971}
+  - {fileID: 2028081122}
+  m_Father: {fileID: 1329619948}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1999336767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1999336765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c78e6e548301c3a43bdc42c148ca642f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SketchBlossom.Battle.BattleTimer
+  timerText: {fileID: 471646972}
+  timerFillImage: {fileID: 2028081123}
+  warningFlashOverlay: {fileID: 0}
+  easyModeDuration: 30
+  hardModeDuration: 15
+  firstWarningTime: 10
+  secondWarningTime: 5
+  safeColor: {r: 1, g: 1, b: 1, a: 1}
+  warningColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  dangerColor: {r: 1, g: 0, b: 0, a: 1}
+  audioSource: {fileID: 0}
+  tickClip: {fileID: 0}
+  urgentTickClip: {fileID: 0}
+  timeoutClip: {fileID: 0}
+  battleManager: {fileID: 948641825}
+--- !u!1 &2028081121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2028081122}
+  - component: {fileID: 2028081124}
+  - component: {fileID: 2028081123}
+  m_Layer: 0
+  m_Name: Timerfill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2028081122
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028081121}
+  m_LocalRotation: {x: -0.0005784636, y: -0.00063660974, z: -0.72107184, w: -0.6928598}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1999336766}
+  m_LocalEulerAnglesHint: {x: -0.007, y: 0.098, z: 92.286}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 600, y: 650}
+  m_SizeDelta: {x: 90, y: 90}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2028081123
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028081121}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 2
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2028081124
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028081121}
+  m_CullTransparentMesh: 1
 --- !u!1 &2071323899
 GameObject:
   m_ObjectHideFlags: 0

--- a/UnityGameFiles/Assets/Scripts/Battle/BattleTimer.cs
+++ b/UnityGameFiles/Assets/Scripts/Battle/BattleTimer.cs
@@ -1,0 +1,207 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+namespace SketchBlossom.Battle
+{
+    /// <summary>
+    /// Round timer for the player turn.
+    /// Runs only during PlayerDrawing and notifies the DrawingBattleSceneManager on timeout.
+    /// </summary>
+    public class BattleTimer : MonoBehaviour
+    {
+        [Header("UI References")]
+        [SerializeField] private TextMeshProUGUI timerText;
+        [SerializeField] private Image timerFillImage;
+        [SerializeField] private Image warningFlashOverlay;
+
+        [Header("Timing (seconds)")]
+        [SerializeField] private float easyModeDuration = 30f; // normal battles
+        [SerializeField] private float hardModeDuration = 15f; // high difficulty battles
+
+        [Header("Warning Thresholds")]
+        [SerializeField] private float firstWarningTime = 10f;
+        [SerializeField] private float secondWarningTime = 5f;
+
+        [Header("Colors")]
+        [SerializeField] private Color safeColor = Color.white;
+        [SerializeField] private Color warningColor = Color.yellow;
+        [SerializeField] private Color dangerColor = Color.red;
+
+        [Header("Audio")]
+        [SerializeField] private AudioSource audioSource;
+        [SerializeField] private AudioClip tickClip;
+        [SerializeField] private AudioClip urgentTickClip;
+        [SerializeField] private AudioClip timeoutClip;
+
+        [Header("Battle Manager Reference")]
+        [SerializeField] private DrawingBattleSceneManager battleManager;
+
+        private float currentDuration;
+        private float remainingTime;
+        private bool isRunning;
+        private bool firstWarningTriggered;
+        private bool secondWarningTriggered;
+        private bool useHardTimeout;
+        private float tickAccumulator;
+
+        /// <summary>
+        /// Starts the timer for the player turn.
+        /// isHardMode = false -> auto submit on timeout
+        /// isHardMode = true  -> player loses the entire turn on timeout
+        /// </summary>
+        public void StartPlayerTurnTimer(bool isHardMode)
+        {
+            useHardTimeout = isHardMode;
+            currentDuration = isHardMode ? hardModeDuration : easyModeDuration;
+
+            remainingTime = currentDuration;
+            firstWarningTriggered = false;
+            secondWarningTriggered = false;
+            tickAccumulator = 0f;
+
+            isRunning = true;
+            ShowUI();
+            UpdateUI();
+        }
+
+        public void Stop()
+        {
+            isRunning = false;
+            HideUI();
+        }
+
+        public void Pause()
+        {
+            isRunning = false;
+        }
+
+        private void Update()
+        {
+            if (!isRunning) return;
+
+            remainingTime -= Time.deltaTime;
+            if (remainingTime < 0f) remainingTime = 0f;
+
+            UpdateUI();
+            HandleWarnings();
+            HandleTickSound();
+
+            if (remainingTime <= 0f)
+            {
+                HandleTimeout();
+            }
+        }
+
+        private void UpdateUI()
+        {
+            if (timerText != null)
+            {
+                timerText.text = Mathf.CeilToInt(remainingTime).ToString("0");
+            }
+
+            if (timerFillImage != null)
+            {
+                float normalized = currentDuration > 0f ? remainingTime / currentDuration : 0f;
+                timerFillImage.fillAmount = normalized;
+
+                if (remainingTime <= secondWarningTime)
+                    timerFillImage.color = dangerColor;
+                else if (remainingTime <= firstWarningTime)
+                    timerFillImage.color = warningColor;
+                else
+                    timerFillImage.color = safeColor;
+            }
+        }
+
+        private void HandleWarnings()
+        {
+            if (!firstWarningTriggered && remainingTime <= firstWarningTime)
+            {
+                firstWarningTriggered = true;
+                TriggerWarningFlash();
+            }
+
+            if (!secondWarningTriggered && remainingTime <= secondWarningTime)
+            {
+                secondWarningTriggered = true;
+                TriggerWarningFlash();
+            }
+        }
+
+        private void TriggerWarningFlash()
+        {
+            if (warningFlashOverlay == null) return;
+
+            warningFlashOverlay.gameObject.SetActive(true);
+            CancelInvoke(nameof(HideWarningFlash));
+            Invoke(nameof(HideWarningFlash), 0.25f);
+        }
+
+        private void HideWarningFlash()
+        {
+            if (warningFlashOverlay != null)
+            {
+                warningFlashOverlay.gameObject.SetActive(false);
+            }
+        }
+
+        private void HandleTickSound()
+        {
+            if (audioSource == null || tickClip == null) return;
+            if (remainingTime <= 0f) return;
+
+            tickAccumulator += Time.deltaTime;
+            if (tickAccumulator >= 1f)
+            {
+                tickAccumulator = 0f;
+
+                AudioClip clipToPlay =
+                    remainingTime <= secondWarningTime && urgentTickClip != null
+                    ? urgentTickClip
+                    : tickClip;
+
+                audioSource.PlayOneShot(clipToPlay);
+            }
+        }
+
+        private void HandleTimeout()
+        {
+            isRunning = false;
+            HideUI();
+
+            if (audioSource != null && timeoutClip != null)
+            {
+                audioSource.PlayOneShot(timeoutClip);
+            }
+
+            if (battleManager == null)
+            {
+                Debug.LogWarning("BattleTimer: no DrawingBattleSceneManager referenced!");
+                return;
+            }
+
+            if (useHardTimeout)
+            {
+                battleManager.OnPlayerTurnTimedOut_Hard();
+            }
+            else
+            {
+                battleManager.OnPlayerTurnTimedOut_AutoSubmit();
+            }
+        }
+
+        private void HideUI()
+        {
+            if (timerText != null) timerText.gameObject.SetActive(false);
+            if (timerFillImage != null) timerFillImage.gameObject.SetActive(false);
+            if (warningFlashOverlay != null) warningFlashOverlay.gameObject.SetActive(false);
+        }
+
+        private void ShowUI()
+        {
+            if (timerText != null) timerText.gameObject.SetActive(true);
+            if (timerFillImage != null) timerFillImage.gameObject.SetActive(true);
+        }
+    }
+}

--- a/UnityGameFiles/Assets/Scripts/Battle/BattleTimer.cs.meta
+++ b/UnityGameFiles/Assets/Scripts/Battle/BattleTimer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c78e6e548301c3a43bdc42c148ca642f


### PR DESCRIPTION
For Issue #38 

This PR adds a full turn-based timer system to the Drawing Battle flow.

##  Features Implemented
### Core Timer System
- Player turn now starts with a countdown timer.
- Timer is displayed visually (countdown text + circular fill bar).
- Timer pauses automatically during enemy turns.
- Timer resets at the start of each player turn.

### Time-Out Behavior
- Normal battles (difficulty < 4★): current drawing is auto-submitted when timer reaches 0.
- Difficult battles (difficulty ≥ 4★): turn is forfeited when time expires.

### Dynamic Difficulty Scaling
- Easy battles: 30 seconds draw time.
- Hard battles: 15 seconds draw time.

### UI & Feedback
- Added TimerPanel with text + fill indicator.
- Color changes based on urgency:
  - White/normal at full time
  - Yellow at 10 seconds
  - Red at 5 seconds
- Optional sounds for ticking, urgent ticking, and timeout.

### Integration Work
- Added new file `BattleTimer.cs`
- Modified `DrawingBattleSceneManager.cs` to:
  - Start/stop/reset timers at the correct moments
  - Receive callbacks for auto-submit and turn-forfeit
- Updated DrawingBattleScene to include new TimerPanel UI.



