### PR TITLE
Use cpu version for torch and torchvision

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,8 +30,8 @@ sniffio==1.3.1
 starlette==0.50.0
 sympy==1.14.0
 tokenizers==0.22.1
-torch==2.9.1
-torchvision==0.24.1
+torch==2.9.1+cpu
+torchvision==0.24.1+cpu
 tqdm==4.67.1
 transformers==4.57.3
 typing-inspection==0.4.2


### PR DESCRIPTION
For linux, the gpu version is automatically installed, making the python zip file too large.