### PR TITLE
Auto-install all Python requirements on macOS/Linux

### DIFF
--- a/.github/workflows/build_py.yml
+++ b/.github/workflows/build_py.yml
@@ -2,47 +2,59 @@ name: Build Python
 
 on:
   workflow_dispatch:
-  
+
 permissions:
   contents: write
   packages: write
   id-token: write
-      
+
 jobs:
   build-py:
     strategy:
       matrix:
-        os: [windows-latest]
-      max-parallel: 1
+        os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # ── Platform-specific Python setup ──────────────────────────
       - name: Install portable python (Windows)
         if: matrix.os == 'windows-latest'
-        run: | 
+        run: |
           curl -L -o python.zip https://www.python.org/ftp/python/3.11.7/python-3.11.7-embed-amd64.zip
           mkdir portable
           powershell Expand-Archive -Path python.zip -DestinationPath portable
+
       - name: Install portable python (macOS)
         if: matrix.os == 'macos-latest'
         run: |
-            curl -L -o python.pkg https://www.python.org/ftp/python/3.11.7/python-3.11.7-macos11.pkg
-            pkgutil --expand-full python.pkg pre
-            pkgutil --expand-full pre/Python_Framework.pkg pythonpkg
-            ls -l pythonpkg/
-            cp -R pythonpkg/Payload/Library/Frameworks/Python.framework/Versions/3.11/* portable/
+          curl -L -o python.pkg https://www.python.org/ftp/python/3.11.7/python-3.11.7-macos11.pkg
+          pkgutil --expand-full python.pkg pre
+          pkgutil --expand-full pre/Python_Framework.pkg pythonpkg
+          mkdir -p portable
+          cp -R pythonpkg/Payload/Library/Frameworks/Python.framework/Versions/3.11/* portable/
 
+      - name: Setup Python (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install portable python (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: python3 -m venv portable --copies
+
+      # ── Pip setup ───────────────────────────────────────────────
       - name: Install pip (Windows)
         if: matrix.os == 'windows-latest'
         run: |
           curl -O https://bootstrap.pypa.io/get-pip.py
           portable\python.exe get-pip.py
-      - name: Install pip (Unix)
-        if: matrix.os != 'windows-latest'
+
+      - name: Install pip (macOS)
+        if: matrix.os == 'macos-latest'
         run: |
           portable/bin/python3 -m ensurepip --upgrade
           portable/bin/python3 -m pip install --upgrade pip
@@ -50,34 +62,53 @@ jobs:
       - name: Fix ._pth file for embeddable Python
         if: runner.os == 'Windows'
         run: (Get-Content portable\python311._pth) -replace '#import site', 'import site' | Set-Content portable\python311._pth
-          
-      # Dependencies installieren
+
+      # ── Dependencies ────────────────────────────────────────────
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: |
           portable\python.exe -m pip install --target portable\Lib\site-packages torch torchvision
           portable\python.exe -m pip install --target portable\Lib\site-packages -r requirements.txt
-      - name: Install dependencies (Unix)
-        if: matrix.os != 'windows-latest'
+
+      - name: Install dependencies (macOS)
+        if: matrix.os == 'macos-latest'
         run: |
-          ls -l portable/
-          portable/bin/python3 -m pip install --target portable/lib/python3.11/site-packages torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          portable/bin/python3 -m pip install --target portable/lib/python3.11/site-packages torch torchvision
           portable/bin/python3 -m pip install --target portable/lib/python3.11/site-packages -r requirements.txt
 
+      - name: Install dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          portable/bin/python3 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          portable/bin/python3 -m pip install -r requirements.txt
+
+      # ── Packaging ───────────────────────────────────────────────
       - name: Zip portable Python (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: Compress-Archive -Path (Get-ChildItem -Path portable) -DestinationPath windows-latest.zip -Force
+
       - name: Zip portable Python (Unix)
         if: matrix.os != 'windows-latest'
         run: |
-            zipName=${{ matrix.os }}.zip
-            zip -r $zipName portable
+          cd portable
+          zip -r ../${{ matrix.os }}.zip .
 
-      - name: Upload as Release Asset
+      # ── Upload ──────────────────────────────────────────────────
+      - name: Upload as Release Asset (Windows)
+        if: matrix.os == 'windows-latest'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: sketchblossom-python-win
+          files: windows-latest.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload as Release Asset (Unix)
+        if: matrix.os != 'windows-latest'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: sketchblossom-python
           files: ${{ matrix.os }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/UnityGameFiles/Assets/Editor/PythonDownloader.cs
+++ b/UnityGameFiles/Assets/Editor/PythonDownloader.cs
@@ -127,6 +127,14 @@ public class PythonDownloader
             Debug.Log("Upgrading pip...");
             await RunPipInstall(pythonExe, "-m pip install --upgrade pip");
 
+            // On macOS/Linux, torch and torchvision are NOT pre-bundled in the
+            // Python zip (unlike Windows).  Install them via pip before the
+            // remaining requirements so the CLIP model can load.
+            #if UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX
+            Debug.Log("Installing PyTorch (torch + torchvision)...");
+            await RunPipInstall(pythonExe, "-m pip install torch torchvision");
+            #endif
+
             // Install packages from requirements.txt
             // On fresh venvs (macOS/Linux) this installs everything;
             // on Windows zips this fixes stale/missing packages


### PR DESCRIPTION
PythonDownloader.cs: Install torch + torchvision via pip on non-Windows platforms before processing requirements.txt. These packages are pre-bundled in the Windows zip but were missing on macOS/Linux, leaving the CLIP model unable to load.

build_py.yml: Expand the CI matrix from Windows-only to all three platforms (Windows, macOS, Linux). Each platform now builds a portable Python with all dependencies and uploads to its respective release tag. Fixed the Unix zip step to exclude the portable/ prefix so extraction matches PythonDownloader expectations.

Windows behaviour is unchanged.
