### PR TITLE
Add 3 enemy difficulty types with multi-plant encounters and procedur…

### DIFF
--- a/UnityGameFiles/Assets/Scripts/Battle/DrawingBattleSceneManager.cs
+++ b/UnityGameFiles/Assets/Scripts/Battle/DrawingBattleSceneManager.cs
@@ -101,6 +101,9 @@ namespace SketchBlossom.Battle
         private bool playerIsBlocking = false;
         private bool enemyIsBlocking = false;
 
+        // Multi-plant encounter tracking
+        private int enemyArtVariant = 0;
+
         private void Start()
         {
             InitializeBattle();
@@ -231,29 +234,51 @@ namespace SketchBlossom.Battle
         }
 
         /// <summary>
-        /// Load enemy unit (from world map encounter or random)
+        /// Load enemy unit (from world map encounter or random).
+        /// For multi-plant encounters, loads the current plant from EnemyEncounterData.
+        /// Uses EnemyPlantArtGenerator to create procedural art (1 of 3 variants per plant type).
         /// </summary>
         private void LoadEnemyUnit()
         {
-            // Check if this is a world map encounter
+            Texture2D enemyArtTexture = null;
+
+            // Check if this is a world map encounter with multi-plant support
             if (EnemyEncounterData.Instance != null && EnemyEncounterData.Instance.isWorldMapEncounter)
             {
-                // Use the enemy data from the world map encounter
-                enemyPlantType = EnemyEncounterData.Instance.encounterPlantType;
-                enemyElement = EnemyEncounterData.Instance.encounterElement;
-                enemyPlantName = EnemyEncounterData.Instance.encounterDisplayName;
+                EnemyPlantEntry currentPlant = EnemyEncounterData.Instance.GetCurrentPlant();
 
-                // Get base stats and potentially scale by difficulty
+                if (currentPlant != null)
+                {
+                    enemyPlantType = currentPlant.plantType;
+                    enemyElement = currentPlant.element;
+                    enemyPlantName = currentPlant.displayName;
+                    enemyArtVariant = currentPlant.artVariant;
+                }
+                else
+                {
+                    // Fallback to legacy fields
+                    enemyPlantType = EnemyEncounterData.Instance.encounterPlantType;
+                    enemyElement = EnemyEncounterData.Instance.encounterElement;
+                    enemyPlantName = EnemyEncounterData.Instance.encounterDisplayName;
+                    enemyArtVariant = Random.Range(0, 3);
+                }
+
+                // Get base stats and scale by difficulty
                 var plantData = PlantRecognitionSystem.GetPlantData(enemyPlantType);
                 int difficulty = EnemyEncounterData.Instance.encounterDifficulty;
 
-                // Scale enemy stats based on difficulty (1-5)
-                float difficultyMultiplier = 1.0f + ((difficulty - 1) * 0.15f); // 1.0x to 1.6x
+                // Scale enemy stats based on difficulty (1-3)
+                float difficultyMultiplier = 1.0f + ((difficulty - 1) * 0.15f);
                 enemyMaxHP = Mathf.RoundToInt(plantData.baseHP * difficultyMultiplier);
                 enemyAttack = Mathf.RoundToInt(plantData.baseAttack * difficultyMultiplier);
                 enemyDefense = Mathf.RoundToInt(plantData.baseDefense * difficultyMultiplier);
 
-                Debug.Log($"World Map Encounter! Enemy: {enemyPlantName} (Difficulty: {difficulty}★)");
+                // Generate procedural art for this enemy plant (1 of 3 variants)
+                enemyArtTexture = EnemyPlantArtGenerator.GeneratePlantArt(enemyPlantType, enemyArtVariant);
+
+                int remaining = EnemyEncounterData.Instance.GetRemainingPlantCount();
+                int total = EnemyEncounterData.Instance.GetPlantCount();
+                Debug.Log($"World Map Encounter! Enemy: {enemyPlantName} [Art Variant {enemyArtVariant + 1}] (Plant {total - remaining + 1}/{total}, Difficulty: {difficulty})");
                 Debug.Log($"Enemy stats: HP:{enemyMaxHP}, ATK:{enemyAttack}, DEF:{enemyDefense}");
             }
             else
@@ -268,15 +293,19 @@ namespace SketchBlossom.Battle
                 enemyMaxHP = plantData.baseHP;
                 enemyAttack = plantData.baseAttack;
                 enemyDefense = plantData.baseDefense;
+                enemyArtVariant = Random.Range(0, 3);
 
-                Debug.Log($"Random enemy: {enemyPlantName} (HP:{enemyMaxHP}, ATK:{enemyAttack}, DEF:{enemyDefense})");
+                // Generate procedural art for random enemy too
+                enemyArtTexture = EnemyPlantArtGenerator.GeneratePlantArt(enemyPlantType, enemyArtVariant);
+
+                Debug.Log($"Random enemy: {enemyPlantName} [Art Variant {enemyArtVariant + 1}] (HP:{enemyMaxHP}, ATK:{enemyAttack}, DEF:{enemyDefense})");
             }
 
-            // Initialize enemy unit display (no drawing texture for enemy)
+            // Initialize enemy unit display with generated art texture
             if (enemyUnit != null)
             {
                 enemyUnit.SetCoroutineRunner(this);
-                enemyUnit.Initialize(enemyPlantType, enemyElement, enemyPlantName, null, false);
+                enemyUnit.Initialize(enemyPlantType, enemyElement, enemyPlantName, enemyArtTexture, false);
             }
         }
 
@@ -382,7 +411,18 @@ namespace SketchBlossom.Battle
         private IEnumerator BattleSequence()
         {
             currentState = BattleState.Start;
-            UpdateActionText("Battle Start!");
+
+            // Show encounter info for multi-plant battles
+            if (EnemyEncounterData.Instance != null && EnemyEncounterData.Instance.GetPlantCount() > 1)
+            {
+                int current = EnemyEncounterData.Instance.GetPlantCount() - EnemyEncounterData.Instance.GetRemainingPlantCount() + 1;
+                int total = EnemyEncounterData.Instance.GetPlantCount();
+                UpdateActionText($"Battle Start! (Plant {current}/{total})");
+            }
+            else
+            {
+                UpdateActionText("Battle Start!");
+            }
             yield return new WaitForSeconds(turnDelay);
 
             while (true)
@@ -993,20 +1033,32 @@ namespace SketchBlossom.Battle
         }
 
         /// <summary>
-        /// Handle victory
+        /// Handle victory. For multi-plant encounters, advances to the next plant if available.
         /// </summary>
         private IEnumerator HandleVictory()
         {
-            UpdateTurnIndicator("VICTORY!");
-            UpdateActionText("You win!");
+            // Check if there are more enemy plants in this encounter
+            bool hasMorePlants = EnemyEncounterData.Instance != null &&
+                                 EnemyEncounterData.Instance.isWorldMapEncounter &&
+                                 EnemyEncounterData.Instance.HasMorePlants();
 
-            Debug.Log("=== VICTORY! Player wins the battle ===");
+            if (hasMorePlants)
+            {
+                int remaining = EnemyEncounterData.Instance.GetRemainingPlantCount() - 1; // -1 for the one we just beat
+                UpdateTurnIndicator("PLANT DEFEATED!");
+                UpdateActionText($"Next opponent incoming! ({remaining} remaining)");
+            }
+            else
+            {
+                UpdateTurnIndicator("VICTORY!");
+                UpdateActionText("You win!");
+            }
 
-            // Ensure player unit stays visible during victory
+            Debug.Log("=== Enemy plant defeated! ===");
+
             if (playerUnit != null)
             {
                 playerUnit.EnsureVisible();
-                Debug.Log("Player unit visibility ensured during victory");
             }
 
             // Trigger enemy death animation
@@ -1016,18 +1068,59 @@ namespace SketchBlossom.Battle
                 enemyUnit.Die(this);
             }
 
-            // Store enemy plant data for potential taming
-            StoreEnemyPlantData();
-
-            // Record victory for player's plant in inventory
-            RecordPlayerVictory();
-
-            // Keep ensuring player visibility during the victory wait period
             yield return new WaitForSeconds(1.5f);
             if (playerUnit != null)
             {
                 playerUnit.EnsureVisible();
             }
+
+            // If more plants to fight, load the next one
+            if (hasMorePlants)
+            {
+                EnemyEncounterData.Instance.AdvanceToNextPlant();
+
+                yield return new WaitForSeconds(1.0f);
+
+                // Load next enemy
+                LoadEnemyUnit();
+
+                // Reset enemy HP bar
+                if (enemyHPBar != null)
+                {
+                    enemyHPBar.Initialize(enemyPlantName, enemyMaxHP);
+                }
+
+                // Reset combat state
+                enemyIsBlocking = false;
+                playerIsBlocking = false;
+                currentState = BattleState.Start;
+
+                // Setup attack animation points for new enemy
+                if (attackAnimationManager != null && playerUnit != null && enemyUnit != null)
+                {
+                    Transform playerTransform = playerUnit.GetTransform();
+                    Transform enemyTransform = enemyUnit.GetTransform();
+                    if (playerTransform != null && enemyTransform != null)
+                    {
+                        attackAnimationManager.SetAttackPoints(playerTransform, enemyTransform);
+                    }
+                }
+
+                UpdateTurnIndicator("NEXT OPPONENT!");
+                UpdateActionText($"A wild {enemyPlantName} appears!");
+                yield return new WaitForSeconds(turnDelay);
+
+                // Resume battle sequence with new enemy
+                StartCoroutine(BattleSequence());
+                yield break;
+            }
+
+            // All plants defeated - full victory
+            // Store enemy plant data for potential taming (last defeated plant)
+            StoreEnemyPlantData();
+
+            // Record victory for player's plant in inventory
+            RecordPlayerVictory();
 
             yield return new WaitForSeconds(1.5f);
 
@@ -1302,10 +1395,11 @@ namespace SketchBlossom.Battle
                     Debug.Log($"BattleUnitDisplay: Ensured unitImage GameObject is active");
                 }
 
-                // If we have a drawing texture (player's drawn plant), use it as the sprite
-                if (drawingTexture != null && isPlayerUnit)
+                // If we have a drawing texture, use it as the sprite (works for both player and enemy)
+                if (drawingTexture != null)
                 {
-                    Debug.Log($"BattleUnitDisplay: Using player's drawing texture as sprite! Texture size: {drawingTexture.width}x{drawingTexture.height}");
+                    string unitType = isPlayerUnit ? "player" : "enemy";
+                    Debug.Log($"BattleUnitDisplay: Using {unitType} texture as sprite! Texture size: {drawingTexture.width}x{drawingTexture.height}");
 
                     // Convert Texture2D to Sprite and keep reference
                     assignedSprite = Texture2DToSprite(drawingTexture);
@@ -1316,18 +1410,18 @@ namespace SketchBlossom.Battle
                         unitImage.color = Color.white; // Reset color to show texture properly
                         unitImage.preserveAspect = true; // Keep aspect ratio
                         unitImage.enabled = true; // Ensure Image component is enabled
-                        Debug.Log($"✓ Drawing sprite applied to player unit! Sprite bounds: {assignedSprite.bounds}");
+                        Debug.Log($"✓ Sprite applied to {unitType} unit! Sprite bounds: {assignedSprite.bounds}");
                     }
                     else
                     {
-                        Debug.LogError("Failed to convert drawing texture to sprite!");
+                        Debug.LogError("Failed to convert texture to sprite!");
                         ApplyElementColor(element);
                     }
                 }
                 else
                 {
-                    // No drawing texture - use element color as fallback (for enemy or if texture missing)
-                    if (drawingTexture == null && isPlayerUnit)
+                    // No texture - use element color as fallback
+                    if (isPlayerUnit)
                     {
                         Debug.LogWarning("BattleUnitDisplay: Player unit has no drawing texture! Using fallback color.");
                     }

--- a/UnityGameFiles/Assets/Scripts/Battle/EnemyPlantArtGenerator.cs
+++ b/UnityGameFiles/Assets/Scripts/Battle/EnemyPlantArtGenerator.cs
@@ -1,0 +1,685 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// Generates procedural art for enemy plants in battle.
+/// Each of the 9 plant types has 3 distinct art variations, all drawn programmatically.
+/// Art is generated as Texture2D sprites at runtime.
+/// </summary>
+public static class EnemyPlantArtGenerator
+{
+    private const int TEX_SIZE = 256;
+
+    /// <summary>
+    /// Get the generated art for a specific plant type and variant (0-2)
+    /// </summary>
+    public static Texture2D GeneratePlantArt(PlantRecognitionSystem.PlantType plantType, int variant)
+    {
+        variant = Mathf.Clamp(variant, 0, 2);
+
+        switch (plantType)
+        {
+            // Fire plants
+            case PlantRecognitionSystem.PlantType.Sunflower:
+                return GenerateSunflower(variant);
+            case PlantRecognitionSystem.PlantType.FireRose:
+                return GenerateFireRose(variant);
+            case PlantRecognitionSystem.PlantType.FlameTulip:
+                return GenerateFlameTulip(variant);
+
+            // Grass plants
+            case PlantRecognitionSystem.PlantType.Cactus:
+                return GenerateCactus(variant);
+            case PlantRecognitionSystem.PlantType.VineFlower:
+                return GenerateVineFlower(variant);
+            case PlantRecognitionSystem.PlantType.GrassSprout:
+                return GenerateGrassSprout(variant);
+
+            // Water plants
+            case PlantRecognitionSystem.PlantType.WaterLily:
+                return GenerateWaterLily(variant);
+            case PlantRecognitionSystem.PlantType.CoralBloom:
+                return GenerateCoralBloom(variant);
+            case PlantRecognitionSystem.PlantType.BubbleFlower:
+                return GenerateBubbleFlower(variant);
+
+            default:
+                return GenerateSunflower(0);
+        }
+    }
+
+    // ========== FIRE PLANTS ==========
+
+    private static Texture2D GenerateSunflower(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color petalColor, centerColor, stemColor;
+
+        switch (variant)
+        {
+            case 0: // Classic bright sunflower
+                petalColor = new Color(1f, 0.8f, 0.1f);
+                centerColor = new Color(0.6f, 0.2f, 0f);
+                stemColor = new Color(0.2f, 0.5f, 0.1f);
+                break;
+            case 1: // Deep orange sunflower
+                petalColor = new Color(1f, 0.5f, 0.1f);
+                centerColor = new Color(0.4f, 0.1f, 0f);
+                stemColor = new Color(0.3f, 0.4f, 0.1f);
+                break;
+            default: // Crimson sunflower
+                petalColor = new Color(0.9f, 0.2f, 0.1f);
+                centerColor = new Color(0.3f, 0.05f, 0f);
+                stemColor = new Color(0.15f, 0.35f, 0.1f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2, cy = TEX_SIZE / 2 + 20;
+
+        // Stem
+        DrawRect(tex, cx - 4, 10, 8, cy - 40, stemColor);
+
+        // Petals (different count per variant)
+        int petalCount = 8 + variant * 2;
+        float petalLen = 40 + variant * 5;
+        for (int i = 0; i < petalCount; i++)
+        {
+            float angle = (360f / petalCount) * i * Mathf.Deg2Rad;
+            DrawPetal(tex, cx, cy, angle, petalLen, 12, petalColor);
+        }
+
+        // Center
+        DrawCircle(tex, cx, cy, 20 + variant * 3, centerColor);
+
+        tex.Apply();
+        return tex;
+    }
+
+    private static Texture2D GenerateFireRose(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color outerColor, innerColor, stemColor;
+
+        switch (variant)
+        {
+            case 0: // Classic red rose
+                outerColor = new Color(0.8f, 0.1f, 0.1f);
+                innerColor = new Color(1f, 0.3f, 0.2f);
+                stemColor = new Color(0.2f, 0.4f, 0.1f);
+                break;
+            case 1: // Magenta rose
+                outerColor = new Color(0.9f, 0.1f, 0.4f);
+                innerColor = new Color(1f, 0.4f, 0.5f);
+                stemColor = new Color(0.15f, 0.35f, 0.15f);
+                break;
+            default: // Dark crimson rose with orange glow
+                outerColor = new Color(0.5f, 0.05f, 0.05f);
+                innerColor = new Color(1f, 0.5f, 0.1f);
+                stemColor = new Color(0.2f, 0.3f, 0.05f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2, cy = TEX_SIZE / 2 + 15;
+
+        // Stem with thorns
+        DrawRect(tex, cx - 3, 10, 6, cy - 30, stemColor);
+        // Thorns
+        DrawRect(tex, cx - 10, cy - 60, 8, 4, stemColor);
+        DrawRect(tex, cx + 5, cy - 80, 8, 4, stemColor);
+
+        // Rose layers (concentric circles with petals)
+        int layers = 3 + variant;
+        for (int l = layers; l >= 0; l--)
+        {
+            float radius = 15 + l * 10;
+            Color layerColor = Color.Lerp(innerColor, outerColor, (float)l / layers);
+            int petalCount = 5 + l;
+            for (int p = 0; p < petalCount; p++)
+            {
+                float angle = ((360f / petalCount) * p + l * 15) * Mathf.Deg2Rad;
+                DrawPetal(tex, cx, cy, angle, radius, 10 + l * 2, layerColor);
+            }
+        }
+
+        // Center bud
+        DrawCircle(tex, cx, cy, 10, innerColor);
+
+        tex.Apply();
+        return tex;
+    }
+
+    private static Texture2D GenerateFlameTulip(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color tipColor, baseColor, stemColor;
+
+        switch (variant)
+        {
+            case 0: // Orange-yellow flame
+                tipColor = new Color(1f, 0.9f, 0.1f);
+                baseColor = new Color(1f, 0.4f, 0f);
+                stemColor = new Color(0.2f, 0.5f, 0.15f);
+                break;
+            case 1: // Blue-white flame
+                tipColor = new Color(0.8f, 0.9f, 1f);
+                baseColor = new Color(0.3f, 0.4f, 1f);
+                stemColor = new Color(0.1f, 0.3f, 0.2f);
+                break;
+            default: // Purple-red flame
+                tipColor = new Color(1f, 0.3f, 0.1f);
+                baseColor = new Color(0.5f, 0.1f, 0.5f);
+                stemColor = new Color(0.2f, 0.35f, 0.1f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2, baseCy = TEX_SIZE / 2 - 10;
+
+        // Tall stem
+        DrawRect(tex, cx - 3, 10, 6, baseCy - 10, stemColor);
+
+        // Tulip cup shape - 3 main petals pointing up
+        int petalWidth = 18 + variant * 3;
+        for (int p = -1; p <= 1; p++)
+        {
+            float offsetX = p * petalWidth * 0.6f;
+            Color c = Color.Lerp(baseColor, tipColor, 0.5f + p * 0.2f);
+            // Draw tapered petal going upward
+            for (int h = 0; h < 60 + variant * 10; h++)
+            {
+                float t = (float)h / (60 + variant * 10);
+                int w = Mathf.RoundToInt(Mathf.Lerp(petalWidth, 3, t * t));
+                Color pixelColor = Color.Lerp(baseColor, tipColor, t);
+                int px = Mathf.RoundToInt(cx + offsetX * (1f - t * 0.5f));
+                int py = baseCy + h;
+                DrawRect(tex, px - w / 2, py, w, 2, pixelColor);
+            }
+        }
+
+        tex.Apply();
+        return tex;
+    }
+
+    // ========== GRASS PLANTS ==========
+
+    private static Texture2D GenerateCactus(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color bodyColor, spikeColor, flowerColor;
+
+        switch (variant)
+        {
+            case 0: // Classic green cactus
+                bodyColor = new Color(0.2f, 0.7f, 0.2f);
+                spikeColor = new Color(0.9f, 0.9f, 0.6f);
+                flowerColor = new Color(1f, 0.4f, 0.6f);
+                break;
+            case 1: // Blue-green cactus
+                bodyColor = new Color(0.15f, 0.55f, 0.45f);
+                spikeColor = new Color(0.8f, 0.8f, 0.7f);
+                flowerColor = new Color(0.9f, 0.9f, 0.2f);
+                break;
+            default: // Dark sage cactus
+                bodyColor = new Color(0.3f, 0.5f, 0.2f);
+                spikeColor = new Color(0.7f, 0.65f, 0.5f);
+                flowerColor = new Color(1f, 0.2f, 0.2f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2, baseY = 30;
+
+        // Main body
+        int bodyW = 30 + variant * 5;
+        int bodyH = 120 + variant * 10;
+        DrawRoundedRect(tex, cx - bodyW / 2, baseY, bodyW, bodyH, bodyColor);
+
+        // Arms (different positions per variant)
+        if (variant == 0)
+        {
+            DrawRect(tex, cx - bodyW / 2 - 20, baseY + 50, 20, 12, bodyColor);
+            DrawRect(tex, cx - bodyW / 2 - 20, baseY + 50, 12, 40, bodyColor);
+            DrawRect(tex, cx + bodyW / 2, baseY + 70, 20, 12, bodyColor);
+            DrawRect(tex, cx + bodyW / 2 + 8, baseY + 70, 12, 35, bodyColor);
+        }
+        else if (variant == 1)
+        {
+            DrawRect(tex, cx - bodyW / 2 - 25, baseY + 40, 25, 12, bodyColor);
+            DrawRect(tex, cx - bodyW / 2 - 25, baseY + 40, 12, 50, bodyColor);
+        }
+        else
+        {
+            DrawRect(tex, cx + bodyW / 2, baseY + 45, 22, 12, bodyColor);
+            DrawRect(tex, cx + bodyW / 2 + 10, baseY + 45, 12, 45, bodyColor);
+            DrawRect(tex, cx - bodyW / 2 - 18, baseY + 80, 18, 12, bodyColor);
+            DrawRect(tex, cx - bodyW / 2 - 18, baseY + 80, 12, 30, bodyColor);
+        }
+
+        // Spikes
+        for (int i = 0; i < 8 + variant * 2; i++)
+        {
+            int sx = cx + Random.Range(-bodyW / 2 + 2, bodyW / 2 - 2);
+            int sy = baseY + Random.Range(5, bodyH - 5);
+            DrawRect(tex, sx, sy, 2, 6, spikeColor);
+        }
+
+        // Flower on top
+        DrawCircle(tex, cx, baseY + bodyH + 5, 8, flowerColor);
+
+        tex.Apply();
+        return tex;
+    }
+
+    private static Texture2D GenerateVineFlower(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color vineColor, flowerColor, leafColor;
+
+        switch (variant)
+        {
+            case 0: // Green vine with purple flowers
+                vineColor = new Color(0.15f, 0.5f, 0.1f);
+                flowerColor = new Color(0.7f, 0.3f, 0.9f);
+                leafColor = new Color(0.2f, 0.7f, 0.15f);
+                break;
+            case 1: // Dark vine with white flowers
+                vineColor = new Color(0.1f, 0.35f, 0.1f);
+                flowerColor = new Color(0.95f, 0.95f, 0.9f);
+                leafColor = new Color(0.15f, 0.55f, 0.1f);
+                break;
+            default: // Brown vine with blue flowers
+                vineColor = new Color(0.35f, 0.25f, 0.1f);
+                flowerColor = new Color(0.3f, 0.5f, 1f);
+                leafColor = new Color(0.25f, 0.6f, 0.2f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2;
+
+        // Curving vine (sine wave)
+        int segments = 80 + variant * 20;
+        for (int i = 0; i < segments; i++)
+        {
+            float t = (float)i / segments;
+            int x = cx + Mathf.RoundToInt(Mathf.Sin(t * Mathf.PI * (2 + variant)) * (30 + variant * 10));
+            int y = 20 + Mathf.RoundToInt(t * 200);
+            DrawCircle(tex, x, y, 3, vineColor);
+
+            // Leaves along vine
+            if (i % (15 - variant * 3) == 0)
+            {
+                int leafDir = (i % 2 == 0) ? 1 : -1;
+                DrawPetal(tex, x, y, leafDir * 0.5f, 15, 8, leafColor);
+            }
+        }
+
+        // Flowers at intervals
+        int flowerCount = 2 + variant;
+        for (int f = 0; f < flowerCount; f++)
+        {
+            float t = 0.3f + (0.5f / flowerCount) * f;
+            int fx = cx + Mathf.RoundToInt(Mathf.Sin(t * Mathf.PI * (2 + variant)) * (30 + variant * 10));
+            int fy = 20 + Mathf.RoundToInt(t * 200);
+            // Flower petals
+            for (int p = 0; p < 5; p++)
+            {
+                float angle = (360f / 5) * p * Mathf.Deg2Rad;
+                DrawPetal(tex, fx, fy, angle, 12, 6, flowerColor);
+            }
+            DrawCircle(tex, fx, fy, 4, Color.Lerp(flowerColor, Color.yellow, 0.5f));
+        }
+
+        tex.Apply();
+        return tex;
+    }
+
+    private static Texture2D GenerateGrassSprout(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color mainColor, tipColor, soilColor;
+
+        switch (variant)
+        {
+            case 0: // Bright green sprouts
+                mainColor = new Color(0.2f, 0.8f, 0.2f);
+                tipColor = new Color(0.5f, 1f, 0.3f);
+                soilColor = new Color(0.4f, 0.25f, 0.1f);
+                break;
+            case 1: // Yellow-green sprouts
+                mainColor = new Color(0.4f, 0.7f, 0.1f);
+                tipColor = new Color(0.7f, 0.9f, 0.2f);
+                soilColor = new Color(0.35f, 0.2f, 0.1f);
+                break;
+            default: // Teal sprouts
+                mainColor = new Color(0.1f, 0.6f, 0.5f);
+                tipColor = new Color(0.3f, 0.9f, 0.7f);
+                soilColor = new Color(0.3f, 0.2f, 0.1f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2;
+
+        // Soil mound
+        DrawCircle(tex, cx, 30, 50, soilColor);
+        DrawRect(tex, cx - 60, 10, 120, 25, soilColor);
+
+        // Grass blades (different counts per variant)
+        int bladeCount = 5 + variant * 3;
+        for (int i = 0; i < bladeCount; i++)
+        {
+            float spread = ((float)i / bladeCount - 0.5f) * 2f;
+            int baseX = cx + Mathf.RoundToInt(spread * 40);
+            int height = 60 + Random.Range(0, 40 + variant * 20);
+            float curve = spread * (0.3f + variant * 0.1f);
+
+            // Draw each blade as a series of points curving outward
+            for (int h = 0; h < height; h++)
+            {
+                float t = (float)h / height;
+                int x = baseX + Mathf.RoundToInt(curve * h * 0.5f);
+                int y = 35 + h;
+                int width = Mathf.RoundToInt(Mathf.Lerp(4, 1, t));
+                Color c = Color.Lerp(mainColor, tipColor, t);
+                DrawRect(tex, x - width / 2, y, width, 2, c);
+            }
+        }
+
+        tex.Apply();
+        return tex;
+    }
+
+    // ========== WATER PLANTS ==========
+
+    private static Texture2D GenerateWaterLily(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color petalColor, padColor, waterColor;
+
+        switch (variant)
+        {
+            case 0: // White lily on green pad
+                petalColor = new Color(1f, 0.95f, 0.95f);
+                padColor = new Color(0.15f, 0.6f, 0.2f);
+                waterColor = new Color(0.2f, 0.4f, 0.8f);
+                break;
+            case 1: // Pink lily on dark pad
+                petalColor = new Color(1f, 0.6f, 0.7f);
+                padColor = new Color(0.1f, 0.4f, 0.15f);
+                waterColor = new Color(0.15f, 0.3f, 0.7f);
+                break;
+            default: // Lavender lily on teal pad
+                petalColor = new Color(0.7f, 0.6f, 1f);
+                padColor = new Color(0.1f, 0.5f, 0.4f);
+                waterColor = new Color(0.1f, 0.35f, 0.6f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2, cy = TEX_SIZE / 2 - 10;
+
+        // Water surface lines
+        for (int w = 0; w < 3; w++)
+        {
+            int wy = cy - 25 + w * 20;
+            for (int x = 20; x < TEX_SIZE - 20; x++)
+            {
+                int yOff = Mathf.RoundToInt(Mathf.Sin(x * 0.05f) * 3);
+                SetPixelSafe(tex, x, wy + yOff, waterColor * 0.7f);
+                SetPixelSafe(tex, x, wy + yOff + 1, waterColor * 0.7f);
+            }
+        }
+
+        // Lily pad (flat oval)
+        DrawEllipse(tex, cx, cy, 55 + variant * 5, 25, padColor);
+
+        // Flower petals
+        int petalCount = 6 + variant * 2;
+        for (int i = 0; i < petalCount; i++)
+        {
+            float angle = (360f / petalCount) * i * Mathf.Deg2Rad;
+            float petalLen = 22 + variant * 3;
+            DrawPetal(tex, cx, cy + 15, angle, petalLen, 8 + variant, petalColor);
+        }
+
+        // Center
+        DrawCircle(tex, cx, cy + 15, 6, new Color(1f, 0.9f, 0.3f));
+
+        tex.Apply();
+        return tex;
+    }
+
+    private static Texture2D GenerateCoralBloom(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color branchColor, tipColor, baseColor;
+
+        switch (variant)
+        {
+            case 0: // Red coral
+                branchColor = new Color(0.9f, 0.3f, 0.3f);
+                tipColor = new Color(1f, 0.6f, 0.5f);
+                baseColor = new Color(0.5f, 0.3f, 0.25f);
+                break;
+            case 1: // Blue coral
+                branchColor = new Color(0.3f, 0.4f, 0.9f);
+                tipColor = new Color(0.5f, 0.7f, 1f);
+                baseColor = new Color(0.2f, 0.25f, 0.5f);
+                break;
+            default: // Purple coral
+                branchColor = new Color(0.6f, 0.2f, 0.7f);
+                tipColor = new Color(0.8f, 0.5f, 1f);
+                baseColor = new Color(0.3f, 0.15f, 0.4f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2;
+
+        // Base rock
+        DrawEllipse(tex, cx, 25, 40, 15, baseColor);
+
+        // Coral branches (tree-like structure)
+        DrawCoralBranch(tex, cx, 35, 90 + variant * 15, 0f, 3 + variant, branchColor, tipColor);
+
+        tex.Apply();
+        return tex;
+    }
+
+    private static void DrawCoralBranch(Texture2D tex, int x, int y, int length, float angle, int depth, Color branchColor, Color tipColor)
+    {
+        if (depth <= 0 || length < 5) return;
+
+        int endX = x + Mathf.RoundToInt(Mathf.Sin(angle) * length * 0.3f);
+        int endY = y + length;
+
+        // Draw this branch segment
+        float t = 1f - (float)depth / 5f;
+        Color c = Color.Lerp(branchColor, tipColor, t);
+        int width = Mathf.Max(2, depth * 2);
+
+        for (int i = 0; i <= length; i++)
+        {
+            float frac = (float)i / length;
+            int px = Mathf.RoundToInt(Mathf.Lerp(x, endX, frac));
+            int py = Mathf.RoundToInt(Mathf.Lerp(y, endY, frac));
+            int w = Mathf.RoundToInt(Mathf.Lerp(width, width / 2f, frac));
+            DrawRect(tex, px - w / 2, py, w, 2, Color.Lerp(branchColor, tipColor, frac * t));
+        }
+
+        // Tip blob
+        if (depth <= 1)
+        {
+            DrawCircle(tex, endX, endY, 5, tipColor);
+        }
+
+        // Branching
+        DrawCoralBranch(tex, endX, endY, length / 2, angle - 0.4f, depth - 1, branchColor, tipColor);
+        DrawCoralBranch(tex, endX, endY, length / 2, angle + 0.4f, depth - 1, branchColor, tipColor);
+    }
+
+    private static Texture2D GenerateBubbleFlower(int variant)
+    {
+        Texture2D tex = CreateBlankTexture();
+        Color bubbleColor, stemColor, highlightColor;
+
+        switch (variant)
+        {
+            case 0: // Blue bubbles
+                bubbleColor = new Color(0.3f, 0.6f, 1f);
+                stemColor = new Color(0.15f, 0.4f, 0.3f);
+                highlightColor = new Color(0.7f, 0.9f, 1f);
+                break;
+            case 1: // Teal bubbles
+                bubbleColor = new Color(0.2f, 0.8f, 0.7f);
+                stemColor = new Color(0.1f, 0.35f, 0.25f);
+                highlightColor = new Color(0.6f, 1f, 0.9f);
+                break;
+            default: // Purple bubbles
+                bubbleColor = new Color(0.5f, 0.3f, 0.9f);
+                stemColor = new Color(0.2f, 0.3f, 0.4f);
+                highlightColor = new Color(0.7f, 0.6f, 1f);
+                break;
+        }
+
+        int cx = TEX_SIZE / 2;
+
+        // Stem
+        DrawRect(tex, cx - 3, 15, 6, 100, stemColor);
+
+        // Bubble clusters
+        int bubbleCount = 5 + variant * 3;
+        for (int i = 0; i < bubbleCount; i++)
+        {
+            int bx = cx + Random.Range(-40 - variant * 10, 40 + variant * 10);
+            int by = 100 + Random.Range(-30, 80 + variant * 15);
+            int radius = Random.Range(8, 18 + variant * 3);
+
+            // Bubble outline
+            DrawCircleOutline(tex, bx, by, radius, bubbleColor);
+            // Inner fill (semi-transparent look)
+            DrawCircle(tex, bx, by, radius - 2, Color.Lerp(bubbleColor, Color.clear, 0.3f));
+            // Highlight
+            DrawCircle(tex, bx - radius / 3, by + radius / 3, radius / 4, highlightColor);
+        }
+
+        tex.Apply();
+        return tex;
+    }
+
+    // ========== DRAWING HELPERS ==========
+
+    private static Texture2D CreateBlankTexture()
+    {
+        Texture2D tex = new Texture2D(TEX_SIZE, TEX_SIZE, TextureFormat.RGBA32, false);
+        tex.filterMode = FilterMode.Point;
+
+        // Fill with transparent
+        Color[] clear = new Color[TEX_SIZE * TEX_SIZE];
+        for (int i = 0; i < clear.Length; i++)
+            clear[i] = Color.clear;
+        tex.SetPixels(clear);
+
+        return tex;
+    }
+
+    private static void SetPixelSafe(Texture2D tex, int x, int y, Color color)
+    {
+        if (x >= 0 && x < TEX_SIZE && y >= 0 && y < TEX_SIZE)
+        {
+            // Alpha blend
+            Color existing = tex.GetPixel(x, y);
+            if (color.a > 0.01f)
+            {
+                Color blended = Color.Lerp(existing, color, color.a);
+                blended.a = Mathf.Max(existing.a, color.a);
+                tex.SetPixel(x, y, blended);
+            }
+        }
+    }
+
+    private static void DrawCircle(Texture2D tex, int cx, int cy, int radius, Color color)
+    {
+        for (int x = cx - radius; x <= cx + radius; x++)
+        {
+            for (int y = cy - radius; y <= cy + radius; y++)
+            {
+                if ((x - cx) * (x - cx) + (y - cy) * (y - cy) <= radius * radius)
+                {
+                    SetPixelSafe(tex, x, y, color);
+                }
+            }
+        }
+    }
+
+    private static void DrawCircleOutline(Texture2D tex, int cx, int cy, int radius, Color color)
+    {
+        for (int x = cx - radius; x <= cx + radius; x++)
+        {
+            for (int y = cy - radius; y <= cy + radius; y++)
+            {
+                int dist = (x - cx) * (x - cx) + (y - cy) * (y - cy);
+                if (dist <= radius * radius && dist >= (radius - 2) * (radius - 2))
+                {
+                    SetPixelSafe(tex, x, y, color);
+                }
+            }
+        }
+    }
+
+    private static void DrawEllipse(Texture2D tex, int cx, int cy, int rx, int ry, Color color)
+    {
+        for (int x = cx - rx; x <= cx + rx; x++)
+        {
+            for (int y = cy - ry; y <= cy + ry; y++)
+            {
+                float dx = (float)(x - cx) / rx;
+                float dy = (float)(y - cy) / ry;
+                if (dx * dx + dy * dy <= 1f)
+                {
+                    SetPixelSafe(tex, x, y, color);
+                }
+            }
+        }
+    }
+
+    private static void DrawRect(Texture2D tex, int x, int y, int w, int h, Color color)
+    {
+        for (int px = x; px < x + w; px++)
+        {
+            for (int py = y; py < y + h; py++)
+            {
+                SetPixelSafe(tex, px, py, color);
+            }
+        }
+    }
+
+    private static void DrawRoundedRect(Texture2D tex, int x, int y, int w, int h, Color color)
+    {
+        int r = Mathf.Min(w, h) / 4;
+        DrawRect(tex, x + r, y, w - 2 * r, h, color);
+        DrawRect(tex, x, y + r, w, h - 2 * r, color);
+        DrawCircle(tex, x + r, y + r, r, color);
+        DrawCircle(tex, x + w - r, y + r, r, color);
+        DrawCircle(tex, x + r, y + h - r, r, color);
+        DrawCircle(tex, x + w - r, y + h - r, r, color);
+    }
+
+    private static void DrawPetal(Texture2D tex, int cx, int cy, float angle, float length, int width, Color color)
+    {
+        for (int i = 0; i < (int)length; i++)
+        {
+            float t = (float)i / length;
+            int x = cx + Mathf.RoundToInt(Mathf.Cos(angle) * i);
+            int y = cy + Mathf.RoundToInt(Mathf.Sin(angle) * i);
+            int w = Mathf.RoundToInt(width * Mathf.Sin(t * Mathf.PI)); // Bulge in middle
+            w = Mathf.Max(1, w);
+
+            for (int dx = -w / 2; dx <= w / 2; dx++)
+            {
+                for (int dy = -w / 2; dy <= w / 2; dy++)
+                {
+                    if (dx * dx + dy * dy <= (w / 2) * (w / 2))
+                    {
+                        SetPixelSafe(tex, x + dx, y + dy, color);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/UnityGameFiles/Assets/Scripts/WorldMap/BattlePreviewUI.cs
+++ b/UnityGameFiles/Assets/Scripts/WorldMap/BattlePreviewUI.cs
@@ -2,9 +2,11 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using UnityEngine.SceneManagement;
+using System.Collections.Generic;
 
 /// <summary>
-/// UI popup that displays battle preview information when interacting with an enemy
+/// UI popup that displays battle preview information when interacting with an enemy.
+/// Shows difficulty level, plant count, and a list of enemy plants in the encounter.
 /// </summary>
 public class BattlePreviewUI : MonoBehaviour
 {
@@ -16,18 +18,20 @@ public class BattlePreviewUI : MonoBehaviour
     [SerializeField] private TextMeshProUGUI flavorText;
     [SerializeField] private Button goToBattleButton;
     [SerializeField] private Button cancelButton;
-    [SerializeField] private Image enemyElementIcon; // Optional: icon for element type
+    [SerializeField] private Image enemyElementIcon;
 
     [Header("Visual Settings")]
     [SerializeField] private Color fireColor = new Color(1f, 0.3f, 0.3f);
     [SerializeField] private Color waterColor = new Color(0.3f, 0.5f, 1f);
     [SerializeField] private Color grassColor = new Color(0.3f, 1f, 0.3f);
+    [SerializeField] private Color easyColor = new Color(0.4f, 0.9f, 0.4f);
+    [SerializeField] private Color mediumColor = new Color(0.9f, 0.7f, 0.2f);
+    [SerializeField] private Color hardColor = new Color(0.9f, 0.3f, 0.3f);
 
     private WorldMapEnemy currentEnemy;
 
     private void Awake()
     {
-        // Setup button listeners
         if (goToBattleButton != null)
         {
             goToBattleButton.onClick.AddListener(OnGoToBattleClicked);
@@ -38,7 +42,6 @@ public class BattlePreviewUI : MonoBehaviour
             cancelButton.onClick.AddListener(OnCancelClicked);
         }
 
-        // Hide popup initially
         if (popupPanel != null)
         {
             popupPanel.SetActive(false);
@@ -46,7 +49,7 @@ public class BattlePreviewUI : MonoBehaviour
     }
 
     /// <summary>
-    /// Show the battle preview popup with enemy data
+    /// Show the battle preview popup with enemy data including difficulty and plant list
     /// </summary>
     public void ShowPreview(WorldMapEnemy enemy)
     {
@@ -57,46 +60,64 @@ public class BattlePreviewUI : MonoBehaviour
         }
 
         currentEnemy = enemy;
+        int difficulty = enemy.GetDifficulty();
+        List<EnemyPlantEntry> plants = enemy.GetEncounterPlants();
 
-        // Populate UI with enemy data
+        // Encounter title
         if (enemyNameText != null)
         {
             enemyNameText.text = enemy.GetDisplayName();
         }
 
+        // Element text - show all elements present in the encounter
         if (elementText != null)
         {
-            PlantRecognitionSystem.ElementType element = enemy.GetElement();
-            elementText.text = $"Element: {element}";
-
-            // Color the element text
-            elementText.color = GetElementColor(element);
+            if (plants.Count == 1)
+            {
+                PlantRecognitionSystem.ElementType element = plants[0].element;
+                string colorHex = ColorUtility.ToHtmlStringRGB(GetElementColor(element));
+                elementText.text = $"Element: <color=#{colorHex}>{element}</color>";
+            }
+            else
+            {
+                string elementsStr = "";
+                for (int i = 0; i < plants.Count; i++)
+                {
+                    string colorHex = ColorUtility.ToHtmlStringRGB(GetElementColor(plants[i].element));
+                    if (i > 0) elementsStr += "  ";
+                    elementsStr += $"<color=#{colorHex}>{plants[i].displayName} ({plants[i].element})</color>";
+                }
+                elementText.text = elementsStr;
+            }
+            elementText.color = Color.white; // Use white since we have rich text coloring
         }
 
+        // Difficulty display with label and stars
         if (difficultyText != null)
         {
-            int difficulty = enemy.GetDifficulty();
-            difficultyText.text = $"Difficulty: {GetDifficultyStars(difficulty)}";
+            string diffLabel = GetDifficultyLabel(difficulty);
+            string stars = GetDifficultyStars(difficulty);
+            string diffColorHex = ColorUtility.ToHtmlStringRGB(GetDifficultyColor(difficulty));
+            difficultyText.text = $"Difficulty: <color=#{diffColorHex}>{diffLabel} {stars}</color>\nPlants: {plants.Count}";
         }
 
+        // Flavor text
         if (flavorText != null)
         {
             flavorText.text = enemy.GetFlavorText();
         }
 
-        // Set element icon color if available
+        // Set element icon to difficulty color
         if (enemyElementIcon != null)
         {
-            enemyElementIcon.color = GetElementColor(enemy.GetElement());
+            enemyElementIcon.color = GetDifficultyColor(difficulty);
         }
 
-        // Show the popup
         if (popupPanel != null)
         {
             popupPanel.SetActive(true);
         }
 
-        // Pause player movement
         PlayerController player = FindObjectOfType<PlayerController>();
         if (player != null)
         {
@@ -104,9 +125,6 @@ public class BattlePreviewUI : MonoBehaviour
         }
     }
 
-    /// <summary>
-    /// Hide the battle preview popup
-    /// </summary>
     public void HidePreview()
     {
         if (popupPanel != null)
@@ -116,7 +134,6 @@ public class BattlePreviewUI : MonoBehaviour
 
         currentEnemy = null;
 
-        // Resume player movement
         PlayerController player = FindObjectOfType<PlayerController>();
         if (player != null)
         {
@@ -132,13 +149,11 @@ public class BattlePreviewUI : MonoBehaviour
             return;
         }
 
-        // Store enemy encounter data for the battle scene
+        // Store encounter data with all plants
         if (EnemyEncounterData.Instance != null)
         {
             EnemyEncounterData.Instance.SetEncounterData(
-                currentEnemy.GetPlantType(),
-                currentEnemy.GetElement(),
-                currentEnemy.GetDisplayName(),
+                currentEnemy.GetEncounterPlants(),
                 currentEnemy.GetDifficulty(),
                 currentEnemy.GetFlavorText()
             );
@@ -149,18 +164,14 @@ public class BattlePreviewUI : MonoBehaviour
             GameObject encounterDataObj = new GameObject("EnemyEncounterData");
             EnemyEncounterData encounterData = encounterDataObj.AddComponent<EnemyEncounterData>();
             encounterData.SetEncounterData(
-                currentEnemy.GetPlantType(),
-                currentEnemy.GetElement(),
-                currentEnemy.GetDisplayName(),
+                currentEnemy.GetEncounterPlants(),
                 currentEnemy.GetDifficulty(),
                 currentEnemy.GetFlavorText()
             );
         }
 
-        // Hide the popup
         HidePreview();
 
-        // Transition to plant selection scene (where player chooses which plant to battle with)
         Debug.Log("Loading PlantSelectionScene for battle preparation...");
         SceneManager.LoadScene("PlantSelectionScene");
     }
@@ -170,31 +181,43 @@ public class BattlePreviewUI : MonoBehaviour
         HidePreview();
     }
 
-    /// <summary>
-    /// Get color based on element type
-    /// </summary>
     private Color GetElementColor(PlantRecognitionSystem.ElementType element)
     {
         switch (element)
         {
-            case PlantRecognitionSystem.ElementType.Fire:
-                return fireColor;
-            case PlantRecognitionSystem.ElementType.Water:
-                return waterColor;
-            case PlantRecognitionSystem.ElementType.Grass:
-                return grassColor;
-            default:
-                return Color.white;
+            case PlantRecognitionSystem.ElementType.Fire: return fireColor;
+            case PlantRecognitionSystem.ElementType.Water: return waterColor;
+            case PlantRecognitionSystem.ElementType.Grass: return grassColor;
+            default: return Color.white;
         }
     }
 
-    /// <summary>
-    /// Get difficulty as stars (★★★☆☆)
-    /// </summary>
+    private Color GetDifficultyColor(int difficulty)
+    {
+        switch (difficulty)
+        {
+            case 1: return easyColor;
+            case 2: return mediumColor;
+            case 3: return hardColor;
+            default: return Color.white;
+        }
+    }
+
+    private string GetDifficultyLabel(int difficulty)
+    {
+        switch (difficulty)
+        {
+            case 1: return "Easy";
+            case 2: return "Medium";
+            case 3: return "Hard";
+            default: return "Unknown";
+        }
+    }
+
     private string GetDifficultyStars(int difficulty)
     {
         string stars = "";
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 3; i++)
         {
             stars += i < difficulty ? "★" : "☆";
         }

--- a/UnityGameFiles/Assets/Scripts/WorldMap/EnemyEncounterData.cs
+++ b/UnityGameFiles/Assets/Scripts/WorldMap/EnemyEncounterData.cs
@@ -1,26 +1,51 @@
 using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// Stores data about a single enemy plant within an encounter
+/// </summary>
+[System.Serializable]
+public class EnemyPlantEntry
+{
+    public PlantRecognitionSystem.PlantType plantType;
+    public PlantRecognitionSystem.ElementType element;
+    public string displayName;
+    public int artVariant; // 0, 1, or 2 - which of the 3 art variations to use
+
+    public EnemyPlantEntry(PlantRecognitionSystem.PlantType type, PlantRecognitionSystem.ElementType elem, string name, int variant)
+    {
+        plantType = type;
+        element = elem;
+        displayName = name;
+        artVariant = variant;
+    }
+}
 
 /// <summary>
 /// Singleton that stores data about the selected enemy encounter on the world map
 /// Persists between scene transitions to pass enemy data to the battle scene
+/// Supports multi-plant encounters (difficulty 1 = 1 plant, difficulty 2 = 2 plants, difficulty 3 = 3 plants)
 /// </summary>
 public class EnemyEncounterData : MonoBehaviour
 {
     public static EnemyEncounterData Instance { get; private set; }
 
-    [Header("Enemy Data")]
+    [Header("Enemy Data (Legacy - first plant)")]
     public PlantRecognitionSystem.PlantType encounterPlantType;
     public PlantRecognitionSystem.ElementType encounterElement;
     public string encounterDisplayName;
     public int encounterDifficulty;
     public string encounterFlavorText;
 
+    [Header("Multi-Plant Encounter")]
+    public List<EnemyPlantEntry> encounterPlants = new List<EnemyPlantEntry>();
+    public int currentPlantIndex = 0; // Which plant the player is currently fighting
+
     [Header("Battle Context")]
-    public bool isWorldMapEncounter = false; // Flag to distinguish from random encounters
+    public bool isWorldMapEncounter = false;
 
     private void Awake()
     {
-        // Singleton pattern
         if (Instance == null)
         {
             Instance = this;
@@ -33,7 +58,36 @@ public class EnemyEncounterData : MonoBehaviour
     }
 
     /// <summary>
-    /// Store enemy data for the upcoming battle
+    /// Store encounter data with multiple plants based on difficulty level
+    /// </summary>
+    public void SetEncounterData(
+        List<EnemyPlantEntry> plants,
+        int difficulty,
+        string flavorText)
+    {
+        encounterPlants = new List<EnemyPlantEntry>(plants);
+        encounterDifficulty = difficulty;
+        encounterFlavorText = flavorText;
+        currentPlantIndex = 0;
+        isWorldMapEncounter = true;
+
+        // Set legacy fields to the first plant for backward compatibility
+        if (plants.Count > 0)
+        {
+            encounterPlantType = plants[0].plantType;
+            encounterElement = plants[0].element;
+            encounterDisplayName = plants[0].displayName;
+        }
+
+        Debug.Log($"Enemy encounter set: Difficulty {difficulty} with {plants.Count} plant(s)");
+        for (int i = 0; i < plants.Count; i++)
+        {
+            Debug.Log($"  Plant {i + 1}: {plants[i].displayName} ({plants[i].element}) [Art Variant {plants[i].artVariant + 1}]");
+        }
+    }
+
+    /// <summary>
+    /// Legacy single-plant setter for backward compatibility
     /// </summary>
     public void SetEncounterData(
         PlantRecognitionSystem.PlantType plantType,
@@ -42,14 +96,72 @@ public class EnemyEncounterData : MonoBehaviour
         int difficulty,
         string flavorText)
     {
+        encounterPlants.Clear();
+        int artVariant = Random.Range(0, 3);
+        encounterPlants.Add(new EnemyPlantEntry(plantType, element, displayName, artVariant));
+
         encounterPlantType = plantType;
         encounterElement = element;
         encounterDisplayName = displayName;
         encounterDifficulty = difficulty;
         encounterFlavorText = flavorText;
+        currentPlantIndex = 0;
         isWorldMapEncounter = true;
 
         Debug.Log($"Enemy encounter set: {displayName} (Difficulty {difficulty})");
+    }
+
+    /// <summary>
+    /// Get the current enemy plant being fought
+    /// </summary>
+    public EnemyPlantEntry GetCurrentPlant()
+    {
+        if (encounterPlants.Count == 0 || currentPlantIndex >= encounterPlants.Count)
+            return null;
+        return encounterPlants[currentPlantIndex];
+    }
+
+    /// <summary>
+    /// Advance to the next plant in the encounter. Returns true if there is a next plant.
+    /// </summary>
+    public bool AdvanceToNextPlant()
+    {
+        currentPlantIndex++;
+        if (currentPlantIndex < encounterPlants.Count)
+        {
+            // Update legacy fields
+            var plant = encounterPlants[currentPlantIndex];
+            encounterPlantType = plant.plantType;
+            encounterElement = plant.element;
+            encounterDisplayName = plant.displayName;
+            Debug.Log($"Advancing to next enemy plant: {plant.displayName} ({currentPlantIndex + 1}/{encounterPlants.Count})");
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Check if there are more plants to fight after the current one
+    /// </summary>
+    public bool HasMorePlants()
+    {
+        return currentPlantIndex < encounterPlants.Count - 1;
+    }
+
+    /// <summary>
+    /// Get total number of plants in this encounter
+    /// </summary>
+    public int GetPlantCount()
+    {
+        return encounterPlants.Count;
+    }
+
+    /// <summary>
+    /// Get remaining plants to fight (including current)
+    /// </summary>
+    public int GetRemainingPlantCount()
+    {
+        return encounterPlants.Count - currentPlantIndex;
     }
 
     /// <summary>
@@ -63,19 +175,35 @@ public class EnemyEncounterData : MonoBehaviour
         encounterDisplayName = "";
         encounterDifficulty = 1;
         encounterFlavorText = "";
+        encounterPlants.Clear();
+        currentPlantIndex = 0;
     }
 
     /// <summary>
-    /// Get difficulty as a star string (★★★☆☆)
+    /// Get difficulty as a star string (★★★)
     /// </summary>
     public string GetDifficultyStars()
     {
         string stars = "";
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 3; i++)
         {
             stars += i < encounterDifficulty ? "★" : "☆";
         }
         return stars;
+    }
+
+    /// <summary>
+    /// Get a display label for the difficulty level
+    /// </summary>
+    public string GetDifficultyLabel()
+    {
+        switch (encounterDifficulty)
+        {
+            case 1: return "Easy";
+            case 2: return "Medium";
+            case 3: return "Hard";
+            default: return "Unknown";
+        }
     }
 
     /// <summary>
@@ -86,13 +214,13 @@ public class EnemyEncounterData : MonoBehaviour
         switch (encounterElement)
         {
             case PlantRecognitionSystem.ElementType.Fire:
-                return "#FF5555"; // Red
+                return "#FF5555";
             case PlantRecognitionSystem.ElementType.Water:
-                return "#5599FF"; // Blue
+                return "#5599FF";
             case PlantRecognitionSystem.ElementType.Grass:
-                return "#55FF55"; // Green
+                return "#55FF55";
             default:
-                return "#FFFFFF"; // White
+                return "#FFFFFF";
         }
     }
 }

--- a/UnityGameFiles/Assets/Scripts/WorldMap/WorldMapEnemy.cs
+++ b/UnityGameFiles/Assets/Scripts/WorldMap/WorldMapEnemy.cs
@@ -1,7 +1,12 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 /// <summary>
-/// Represents an enemy entity on the world map that the player can interact with
+/// Represents an enemy entity on the world map that the player can interact with.
+/// Difficulty level determines the number of plants in the encounter:
+///   Difficulty 1 = 1 random plant
+///   Difficulty 2 = 2 random plants
+///   Difficulty 3 = 3 random plants
 /// </summary>
 public class WorldMapEnemy : MonoBehaviour
 {
@@ -9,15 +14,18 @@ public class WorldMapEnemy : MonoBehaviour
     [SerializeField] private PlantRecognitionSystem.PlantType enemyPlantType;
     [SerializeField] private PlantRecognitionSystem.ElementType enemyElement;
     [SerializeField] private string enemyDisplayName;
-    [SerializeField] private int difficulty = 1; // 1-5 difficulty rating
+    [SerializeField] private int difficulty = 1; // 1-3: also determines number of plants
     [SerializeField] [TextArea(3, 5)] private string flavorText;
+
+    [Header("Multi-Plant Encounter")]
+    [SerializeField] private List<EnemyPlantEntry> enemyPlants = new List<EnemyPlantEntry>();
 
     [Header("Interaction Settings")]
     [SerializeField] private float interactionRange = 2f;
     [SerializeField] private KeyCode interactionKey = KeyCode.E;
 
     [Header("Visual Feedback")]
-    [SerializeField] private GameObject interactionPrompt; // "Press E to Interact" UI
+    [SerializeField] private GameObject interactionPrompt;
     [SerializeField] private SpriteRenderer spriteRenderer;
     [SerializeField] private Color highlightColor = Color.yellow;
 
@@ -47,23 +55,19 @@ public class WorldMapEnemy : MonoBehaviour
 
     private void Start()
     {
-        // Find the player
         GameObject playerObj = GameObject.FindGameObjectWithTag("Player");
         if (playerObj != null)
         {
             player = playerObj.transform;
         }
 
-        // Find the scene manager
         sceneManager = FindObjectOfType<WorldMapSceneManager>();
 
-        // Create interaction prompt if it doesn't exist
         if (interactionPrompt == null)
         {
             CreateInteractionPrompt();
         }
 
-        // Hide interaction prompt initially
         if (interactionPrompt != null)
         {
             interactionPrompt.SetActive(false);
@@ -75,20 +79,17 @@ public class WorldMapEnemy : MonoBehaviour
     /// </summary>
     private void CreateInteractionPrompt()
     {
-        // Create a simple world space canvas for the prompt
         GameObject promptObj = new GameObject("InteractionPrompt");
         promptObj.transform.SetParent(transform);
-        promptObj.transform.localPosition = new Vector3(0, 1.5f, 0); // Above the enemy
+        promptObj.transform.localPosition = new Vector3(0, 1.5f, 0);
 
         Canvas canvas = promptObj.AddComponent<Canvas>();
         canvas.renderMode = RenderMode.WorldSpace;
 
-        // Make it small in world space (1 unit = reasonable size)
         RectTransform canvasRect = canvas.GetComponent<RectTransform>();
-        canvasRect.sizeDelta = new Vector2(2f, 0.5f); // 2 units wide, 0.5 units tall
-        canvasRect.localScale = new Vector3(0.01f, 0.01f, 0.01f); // Scale down for crisp text
+        canvasRect.sizeDelta = new Vector2(2f, 0.5f);
+        canvasRect.localScale = new Vector3(0.01f, 0.01f, 0.01f);
 
-        // Add text
         GameObject textObj = new GameObject("Text");
         textObj.transform.SetParent(promptObj.transform);
 
@@ -107,13 +108,12 @@ public class WorldMapEnemy : MonoBehaviour
         textRect.offsetMin = Vector2.zero;
         textRect.offsetMax = Vector2.zero;
 
-        // Add background panel for visibility
         GameObject bgObj = new GameObject("Background");
         bgObj.transform.SetParent(promptObj.transform);
-        bgObj.transform.SetAsFirstSibling(); // Behind text
+        bgObj.transform.SetAsFirstSibling();
 
         UnityEngine.UI.Image bgImage = bgObj.AddComponent<UnityEngine.UI.Image>();
-        bgImage.color = new Color(0, 0, 0, 0.7f); // Semi-transparent black
+        bgImage.color = new Color(0, 0, 0, 0.7f);
 
         RectTransform bgRect = bgImage.GetComponent<RectTransform>();
         bgRect.anchorMin = Vector2.zero;
@@ -128,18 +128,15 @@ public class WorldMapEnemy : MonoBehaviour
     {
         if (player == null) return;
 
-        // Check distance to player
         float distance = Vector2.Distance(transform.position, player.position);
         bool wasInRange = playerInRange;
         playerInRange = distance <= interactionRange;
 
-        // Update visual feedback
         if (playerInRange != wasInRange)
         {
             OnRangeChanged(playerInRange);
         }
 
-        // Check for interaction input
         if (playerInRange && Input.GetKeyDown(interactionKey))
         {
             OnInteract();
@@ -148,13 +145,11 @@ public class WorldMapEnemy : MonoBehaviour
 
     private void OnRangeChanged(bool inRange)
     {
-        // Show/hide interaction prompt
         if (interactionPrompt != null)
         {
             interactionPrompt.SetActive(inRange);
         }
 
-        // Highlight enemy when player is in range
         if (spriteRenderer != null)
         {
             spriteRenderer.color = inRange ? highlightColor : originalColor;
@@ -174,66 +169,117 @@ public class WorldMapEnemy : MonoBehaviour
     }
 
     /// <summary>
-    /// Generate random enemy data
+    /// Generate a random enemy encounter. Difficulty determines number of plants (1-3).
     /// </summary>
     private void GenerateRandomEnemy()
     {
-        // Random plant type
-        System.Array plantTypes = System.Enum.GetValues(typeof(PlantRecognitionSystem.PlantType));
-        enemyPlantType = (PlantRecognitionSystem.PlantType)plantTypes.GetValue(Random.Range(0, plantTypes.Length));
+        // Random difficulty 1-3
+        difficulty = Random.Range(1, 4);
 
-        // Get plant data
-        var plantData = PlantRecognitionSystem.GetPlantData(enemyPlantType);
-        enemyElement = plantData.element;
-        enemyDisplayName = plantData.displayName;
+        // Generate plants based on difficulty (difficulty = number of plants)
+        GenerateEncounterPlants();
 
-        // Random difficulty (1-5)
-        difficulty = Random.Range(1, 6);
+        // Set primary display data from first plant
+        if (enemyPlants.Count > 0)
+        {
+            var firstPlant = enemyPlants[0];
+            enemyPlantType = firstPlant.plantType;
+            enemyElement = firstPlant.element;
+            enemyDisplayName = GetEncounterDisplayName();
+        }
 
-        // Generate flavor text based on plant type
-        flavorText = GenerateFlavorText(enemyPlantType, enemyElement);
+        // Generate flavor text
+        flavorText = GenerateFlavorText();
 
-        // Set sprite color based on element
+        // Set sprite color based on difficulty
         if (spriteRenderer != null)
         {
-            spriteRenderer.color = GetElementColor(enemyElement);
+            spriteRenderer.color = GetDifficultyColor();
             originalColor = spriteRenderer.color;
         }
     }
 
-    private string GenerateFlavorText(PlantRecognitionSystem.PlantType plantType, PlantRecognitionSystem.ElementType element)
+    /// <summary>
+    /// Generate random plants for the encounter based on difficulty level
+    /// </summary>
+    private void GenerateEncounterPlants()
     {
-        string[] fireTexts = new string[]
+        enemyPlants.Clear();
+        System.Array plantTypes = System.Enum.GetValues(typeof(PlantRecognitionSystem.PlantType));
+
+        for (int i = 0; i < difficulty; i++)
         {
-            "A fierce plant warrior burning with determination!",
-            "This blazing bloom won't go down without a fight!",
-            "Feel the heat of battle against this fiery foe!"
+            var plantType = (PlantRecognitionSystem.PlantType)plantTypes.GetValue(Random.Range(0, plantTypes.Length));
+            var plantData = PlantRecognitionSystem.GetPlantData(plantType);
+            int artVariant = Random.Range(0, 3); // 1 of 3 art variations
+
+            enemyPlants.Add(new EnemyPlantEntry(
+                plantType,
+                plantData.element,
+                plantData.displayName,
+                artVariant
+            ));
+        }
+    }
+
+    /// <summary>
+    /// Get a display name for the encounter based on difficulty and plants
+    /// </summary>
+    private string GetEncounterDisplayName()
+    {
+        if (enemyPlants.Count == 1)
+        {
+            return enemyPlants[0].displayName;
+        }
+        else
+        {
+            return $"Wild Pack ({enemyPlants.Count} plants)";
+        }
+    }
+
+    private string GenerateFlavorText()
+    {
+        string[] easyTexts = new string[]
+        {
+            "A lone wild plant stands in your path!",
+            "A solitary bloom challenges you to battle!",
+            "A single wild plant guards this area!"
         };
 
-        string[] waterTexts = new string[]
+        string[] mediumTexts = new string[]
         {
-            "A calm yet powerful plant waiting to strike!",
-            "This aquatic bloom flows with ancient wisdom!",
-            "Dive into battle against this mysterious water guardian!"
+            "A pair of wild plants have joined forces!",
+            "Two fierce blooms block your way!",
+            "A duo of wild plants stand ready to fight!"
         };
 
-        string[] grassTexts = new string[]
+        string[] hardTexts = new string[]
         {
-            "A resilient plant rooted in strength!",
-            "This verdant warrior draws power from the earth!",
-            "Nature's champion stands ready to defend its territory!"
+            "A trio of wild plants form an imposing wall!",
+            "Three fierce blooms challenge all who approach!",
+            "A fearsome pack of wild plants guards this territory!"
         };
 
-        switch (element)
+        switch (difficulty)
         {
-            case PlantRecognitionSystem.ElementType.Fire:
-                return fireTexts[Random.Range(0, fireTexts.Length)];
-            case PlantRecognitionSystem.ElementType.Water:
-                return waterTexts[Random.Range(0, waterTexts.Length)];
-            case PlantRecognitionSystem.ElementType.Grass:
-                return grassTexts[Random.Range(0, grassTexts.Length)];
-            default:
-                return "A mysterious plant appears before you!";
+            case 1: return easyTexts[Random.Range(0, easyTexts.Length)];
+            case 2: return mediumTexts[Random.Range(0, mediumTexts.Length)];
+            case 3: return hardTexts[Random.Range(0, hardTexts.Length)];
+            default: return "A mysterious plant appears before you!";
+        }
+    }
+
+    /// <summary>
+    /// Get a color representing the difficulty level for the world map sprite
+    /// </summary>
+    private Color GetDifficultyColor()
+    {
+        switch (difficulty)
+        {
+            case 1: return new Color(0.4f, 0.9f, 0.4f); // Green - Easy
+            case 2: return new Color(0.9f, 0.7f, 0.2f); // Yellow/Orange - Medium
+            case 3: return new Color(0.9f, 0.3f, 0.3f); // Red - Hard
+            default: return Color.white;
         }
     }
 
@@ -242,66 +288,94 @@ public class WorldMapEnemy : MonoBehaviour
         switch (element)
         {
             case PlantRecognitionSystem.ElementType.Fire:
-                return new Color(1f, 0.3f, 0.3f); // Red
+                return new Color(1f, 0.3f, 0.3f);
             case PlantRecognitionSystem.ElementType.Water:
-                return new Color(0.3f, 0.5f, 1f); // Blue
+                return new Color(0.3f, 0.5f, 1f);
             case PlantRecognitionSystem.ElementType.Grass:
-                return new Color(0.3f, 1f, 0.3f); // Green
+                return new Color(0.3f, 1f, 0.3f);
             default:
                 return Color.white;
         }
     }
 
-    // Public getters for enemy data
+    // Public getters
     public PlantRecognitionSystem.PlantType GetPlantType() => enemyPlantType;
     public PlantRecognitionSystem.ElementType GetElement() => enemyElement;
     public string GetDisplayName() => enemyDisplayName;
     public int GetDifficulty() => difficulty;
     public string GetFlavorText() => flavorText;
+    public List<EnemyPlantEntry> GetEncounterPlants() => enemyPlants;
 
-    // Public setters for manual configuration
-    public void SetEnemyData(PlantRecognitionSystem.PlantType plantType, int difficultyLevel, string customFlavorText = "")
+    /// <summary>
+    /// Set enemy data with a specific difficulty and auto-generate plants
+    /// </summary>
+    public void SetEnemyData(int difficultyLevel, string customFlavorText = "")
     {
-        enemyPlantType = plantType;
-        var plantData = PlantRecognitionSystem.GetPlantData(enemyPlantType);
-        enemyElement = plantData.element;
-        enemyDisplayName = plantData.displayName;
-        difficulty = difficultyLevel;
+        difficulty = Mathf.Clamp(difficultyLevel, 1, 3);
+        GenerateEncounterPlants();
 
-        if (!string.IsNullOrEmpty(customFlavorText))
+        if (enemyPlants.Count > 0)
         {
-            flavorText = customFlavorText;
+            var firstPlant = enemyPlants[0];
+            enemyPlantType = firstPlant.plantType;
+            enemyElement = firstPlant.element;
+            enemyDisplayName = GetEncounterDisplayName();
         }
-        else
-        {
-            flavorText = GenerateFlavorText(enemyPlantType, enemyElement);
-        }
+
+        flavorText = !string.IsNullOrEmpty(customFlavorText) ? customFlavorText : GenerateFlavorText();
 
         if (spriteRenderer != null)
         {
-            spriteRenderer.color = GetElementColor(enemyElement);
+            spriteRenderer.color = GetDifficultyColor();
             originalColor = spriteRenderer.color;
         }
     }
 
-    // Optional: Visualize interaction range in editor
+    /// <summary>
+    /// Legacy setter for backward compatibility
+    /// </summary>
+    public void SetEnemyData(PlantRecognitionSystem.PlantType plantType, int difficultyLevel, string customFlavorText = "")
+    {
+        difficulty = Mathf.Clamp(difficultyLevel, 1, 3);
+        enemyPlantType = plantType;
+        var plantData = PlantRecognitionSystem.GetPlantData(enemyPlantType);
+        enemyElement = plantData.element;
+        enemyDisplayName = plantData.displayName;
+
+        // Build plants list with the specified plant as first
+        enemyPlants.Clear();
+        enemyPlants.Add(new EnemyPlantEntry(plantType, plantData.element, plantData.displayName, Random.Range(0, 3)));
+
+        // Add additional random plants for higher difficulties
+        System.Array plantTypes = System.Enum.GetValues(typeof(PlantRecognitionSystem.PlantType));
+        for (int i = 1; i < difficulty; i++)
+        {
+            var randomType = (PlantRecognitionSystem.PlantType)plantTypes.GetValue(Random.Range(0, plantTypes.Length));
+            var randomData = PlantRecognitionSystem.GetPlantData(randomType);
+            enemyPlants.Add(new EnemyPlantEntry(randomType, randomData.element, randomData.displayName, Random.Range(0, 3)));
+        }
+
+        enemyDisplayName = GetEncounterDisplayName();
+        flavorText = !string.IsNullOrEmpty(customFlavorText) ? customFlavorText : GenerateFlavorText();
+
+        if (spriteRenderer != null)
+        {
+            spriteRenderer.color = GetDifficultyColor();
+            originalColor = spriteRenderer.color;
+        }
+    }
+
     private void OnDrawGizmosSelected()
     {
         Gizmos.color = Color.yellow;
         Gizmos.DrawWireSphere(transform.position, interactionRange);
     }
 
-    /// <summary>
-    /// Remove this enemy from the world map (e.g., after defeating it)
-    /// </summary>
     public void RemoveEnemy()
     {
         Destroy(gameObject);
     }
 
-    /// <summary>
-    /// Temporarily disable this enemy (e.g., during battle)
-    /// </summary>
     public void SetActive(bool active)
     {
         gameObject.SetActive(active);

--- a/UnityGameFiles/Assets/Scripts/WorldMap/WorldMapSceneManager.cs
+++ b/UnityGameFiles/Assets/Scripts/WorldMap/WorldMapSceneManager.cs
@@ -2,8 +2,9 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 
 /// <summary>
-/// Main manager for the World Map scene
-/// Handles player spawning, enemy setup, and scene transitions
+/// Main manager for the World Map scene.
+/// Handles player spawning, enemy setup, and scene transitions.
+/// Spawns enemies with varying difficulty levels (1-3) representing different encounter sizes.
 /// </summary>
 public class WorldMapSceneManager : MonoBehaviour
 {
@@ -22,27 +23,24 @@ public class WorldMapSceneManager : MonoBehaviour
 
     [Header("Scene Settings")]
     [SerializeField] private bool spawnEnemiesOnStart = true;
-    [SerializeField] private int numberOfEnemies = 2;
+    [SerializeField] private int numberOfEnemies = 3; // One of each difficulty by default
+    [SerializeField] private bool isFirstEncounter = false; // Set true for tutorial/first map
 
     private void Start()
     {
-        // Initialize player
         SetupPlayer();
 
-        // Initialize enemies
         if (spawnEnemiesOnStart)
         {
             SetupEnemies();
         }
 
-        // Ensure EnemyEncounterData singleton exists
         if (EnemyEncounterData.Instance == null)
         {
             GameObject encounterDataObj = new GameObject("EnemyEncounterData");
             encounterDataObj.AddComponent<EnemyEncounterData>();
         }
 
-        // Find battle preview UI if not assigned
         if (battlePreviewUI == null)
         {
             battlePreviewUI = FindObjectOfType<BattlePreviewUI>();
@@ -53,17 +51,14 @@ public class WorldMapSceneManager : MonoBehaviour
 
     private void SetupPlayer()
     {
-        // If player controller is already assigned, just set position
         if (playerController != null)
         {
             playerController.transform.position = playerSpawnPosition;
             return;
         }
 
-        // Try to find existing player in scene
         playerController = FindObjectOfType<PlayerController>();
 
-        // If no player exists, spawn one
         if (playerController == null && playerPrefab != null)
         {
             GameObject playerObj = Instantiate(playerPrefab, playerSpawnPosition, Quaternion.identity);
@@ -71,7 +66,6 @@ public class WorldMapSceneManager : MonoBehaviour
             playerObj.tag = "Player";
             playerController = playerObj.GetComponent<PlayerController>();
 
-            // Add PlayerController if not on prefab
             if (playerController == null)
             {
                 playerController = playerObj.AddComponent<PlayerController>();
@@ -95,23 +89,34 @@ public class WorldMapSceneManager : MonoBehaviour
             return;
         }
 
-        // Otherwise, spawn new enemies
         if (enemyPrefab == null)
         {
             Debug.LogWarning("Enemy prefab not assigned! Cannot spawn enemies.");
             return;
         }
 
-        // Determine spawn points
         Vector3[] spawnPositions = GetEnemySpawnPositions();
 
-        // Spawn enemies
         enemies = new WorldMapEnemy[numberOfEnemies];
         for (int i = 0; i < numberOfEnemies; i++)
         {
             Vector3 spawnPos = spawnPositions[i];
             GameObject enemyObj = Instantiate(enemyPrefab, spawnPos, Quaternion.identity);
-            enemyObj.name = $"Enemy_{i + 1}";
+
+            // Determine difficulty: if first encounter, all are difficulty 1
+            // Otherwise, cycle through difficulties 1, 2, 3
+            int difficulty;
+            if (isFirstEncounter)
+            {
+                difficulty = 1;
+            }
+            else
+            {
+                difficulty = (i % 3) + 1; // 1, 2, 3, 1, 2, 3...
+            }
+
+            string diffLabel = difficulty == 1 ? "Easy" : difficulty == 2 ? "Medium" : "Hard";
+            enemyObj.name = $"Enemy_{diffLabel}_{i + 1}";
 
             WorldMapEnemy enemy = enemyObj.GetComponent<WorldMapEnemy>();
             if (enemy == null)
@@ -119,15 +124,17 @@ public class WorldMapSceneManager : MonoBehaviour
                 enemy = enemyObj.AddComponent<WorldMapEnemy>();
             }
 
+            // Set difficulty which also generates appropriate number of plants
+            enemy.SetEnemyData(difficulty);
+
             enemies[i] = enemy;
 
-            Debug.Log($"Spawned enemy {i + 1} at {spawnPos}");
+            Debug.Log($"Spawned {diffLabel} enemy (difficulty {difficulty}) at {spawnPos}");
         }
     }
 
     private Vector3[] GetEnemySpawnPositions()
     {
-        // If spawn points are defined, use those
         if (enemySpawnPoints != null && enemySpawnPoints.Length >= numberOfEnemies)
         {
             Vector3[] positions = new Vector3[numberOfEnemies];
@@ -138,11 +145,9 @@ public class WorldMapSceneManager : MonoBehaviour
             return positions;
         }
 
-        // Otherwise, generate random positions around the player
         Vector3[] randomPositions = new Vector3[numberOfEnemies];
         for (int i = 0; i < numberOfEnemies; i++)
         {
-            // Random position in a circle around player
             float angle = (360f / numberOfEnemies) * i;
             float distance = Random.Range(5f, 10f);
 
@@ -169,17 +174,11 @@ public class WorldMapSceneManager : MonoBehaviour
         battlePreviewUI.ShowPreview(enemy);
     }
 
-    /// <summary>
-    /// Return to main menu
-    /// </summary>
     public void ReturnToMainMenu()
     {
         SceneManager.LoadScene("MainMenuScene");
     }
 
-    /// <summary>
-    /// Open inventory scene
-    /// </summary>
     public void OpenInventory()
     {
         SceneManager.LoadScene("InventoryScene");
@@ -192,7 +191,6 @@ public class WorldMapSceneManager : MonoBehaviour
     {
         if (removeDefeated && EnemyEncounterData.Instance != null && EnemyEncounterData.Instance.isWorldMapEncounter)
         {
-            // Find and remove the defeated enemy
             foreach (WorldMapEnemy enemy in enemies)
             {
                 if (enemy != null && enemy.GetPlantType() == EnemyEncounterData.Instance.encounterPlantType)
@@ -202,7 +200,6 @@ public class WorldMapSceneManager : MonoBehaviour
                 }
             }
 
-            // Clear encounter data
             EnemyEncounterData.Instance.ClearEncounterData();
         }
     }


### PR DESCRIPTION
…al art

- Difficulty 1 (Easy): 1 random plant to fight
- Difficulty 2 (Medium): 2 random plants fought sequentially
- Difficulty 3 (Hard): 3 random plants fought sequentially

Key changes:
- EnemyEncounterData: supports multiple EnemyPlantEntry per encounter with sequential plant tracking (advance, remaining count, current plant)
- WorldMapEnemy: generates encounter plants based on difficulty, color-coded sprites (green/yellow/red) on world map by difficulty level
- BattlePreviewUI: shows difficulty label (Easy/Medium/Hard), stars, plant count, and per-plant element info with rich text coloring
- WorldMapSceneManager: spawns one enemy of each difficulty by default
- EnemyPlantArtGenerator: procedurally generates unique art for all 9 plant types with 3 distinct color/shape variants each (27 total artworks)
- DrawingBattleSceneManager: after defeating an enemy plant in a multi-plant encounter, loads the next plant with fresh HP/art and continues the battle; enemy units now display generated art textures instead of flat colors

https://claude.ai/code/session_01KazijmirUkLRZVYnEi5oT5